### PR TITLE
Remove the margin on the card hitboxes

### DIFF
--- a/src/card.tsx
+++ b/src/card.tsx
@@ -10,7 +10,7 @@ type CardProps = {
 const cardWidth = 0.057;
 const cardHeight = 0.08;
 const cardDepth = 0.001;
-const cardGrabMargin = 0.01;
+const cardGrabMargin = 0.00;
 
 export const PlayingCard: React.FC<CardProps> = (props) => {
 


### PR DESCRIPTION
The grabber already has enough volume that the thinness of the cards doesn't feel problematic to me. And this might make it a little bit easier to pick out specific cards when they are close together. 